### PR TITLE
Bos 234

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,6 @@ MigrationBackup/
 FodyWeavers.xsd
 
 tmp/
+
+# BOS-234
+appsettings.json

--- a/App.Core/App.Core.csproj
+++ b/App.Core/App.Core.csproj
@@ -28,4 +28,10 @@
   <ItemGroup>
     <Folder Include="Migrations\" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/App.Core/DataAccess/BoschContext.cs
+++ b/App.Core/DataAccess/BoschContext.cs
@@ -1,5 +1,7 @@
-﻿using App.Core.Models;
+﻿using App.Core.Helpers;
+using App.Core.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 
 namespace App.Core.DataAccess
 {
@@ -50,7 +52,7 @@ namespace App.Core.DataAccess
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlServer(@"Data Source=127.0.0.1;Initial Catalog=TestDB;User ID=sa;Password=meinPasswort1234;TrustServerCertificate=True");
+            optionsBuilder.UseSqlServer(ConfigurationHelper.Configuration.GetConnectionString("BoschContext"));
         }
 
         public override int SaveChanges()

--- a/App.Core/Helpers/ConfigurationHelper.cs
+++ b/App.Core/Helpers/ConfigurationHelper.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.Configuration;
+using System.Reflection;
+
+namespace App.Core.Helpers
+{
+    public class ConfigurationHelper
+    {
+        private static readonly Lazy<IConfigurationRoot> configurationInstance = new Lazy<IConfigurationRoot>(() => CreateConfiguration());
+        private static readonly Lazy<IConfigurationBuilder> builderInstance = new Lazy<IConfigurationBuilder>(() => CreateBuilder());
+
+        public static IConfigurationRoot Configuration => configurationInstance.Value;
+
+        private ConfigurationHelper()
+        {
+        }
+
+        public static IConfigurationBuilder GetConfigurationBuilder()
+        {
+            return builderInstance.Value;
+        }
+
+        private static IConfigurationRoot CreateConfiguration()
+        {
+            return GetConfigurationBuilder().Build();
+        }
+
+        private static IConfigurationBuilder CreateBuilder()
+        {
+            var builder = new ConfigurationBuilder();
+            var runtimePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            var appsettings = "appsettings.json";
+            var fullPath = Path.Combine(runtimePath, appsettings);
+
+            return builder.SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile(fullPath, optional: false, reloadOnChange: true)
+                .AddEnvironmentVariables();
+        }
+    }
+}

--- a/App.Core/appsettings.json
+++ b/App.Core/appsettings.json
@@ -20,5 +20,8 @@
         }
       }
     ]
-  }
-}
+  },
+    "ConnectionStrings": {
+      "BoschContext": "Data Source=localhost;Initial Catalog=TestDB;User ID=sa;Password=CHANGEMEBRO;TrustServerCertificate=True"
+   }
+ }

--- a/App/App.csproj
+++ b/App/App.csproj
@@ -48,9 +48,6 @@
     <ProjectReference Include="..\App.Core\App.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <Page Update="Views\CreateDiagnosePage.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/App/App.xaml.cs
+++ b/App/App.xaml.cs
@@ -2,6 +2,7 @@
 using App.Contracts.Services;
 using App.Core.Contracts.Services;
 using App.Core.DataAccess;
+using App.Core.Helpers;
 using App.Core.Models;
 using App.Core.Services;
 using App.Core.Services.Interfaces;
@@ -49,13 +50,11 @@ public partial class App : Application
     {
         InitializeComponent();
 
-        var builder = new ConfigurationBuilder();
-        ConfigSetup(builder);
+        //var configuration = ConfigurationHelper.Configuration;
 
         Log.Logger = new LoggerConfiguration()
-            .ReadFrom.Configuration(builder.Build())
+            .ReadFrom.Configuration(ConfigurationHelper.Configuration)
             .CreateLogger();
-
 
         Host = Microsoft.Extensions.Hosting.Host.
         CreateDefaultBuilder().
@@ -122,22 +121,14 @@ public partial class App : Application
 
             // Configuration
             services.Configure<LocalSettingsOptions>(context.Configuration.GetSection(nameof(LocalSettingsOptions)));
+ 
             services.AddDbContext<BoschContext>(
-                    options => options.UseSqlServer(@"Data Source=localhost;Initial Catalog=TestDB;User ID=sa;Password=meinPasswort1234;TrustServerCertificate=True"),
-                    ServiceLifetime.Transient);
+                options => options.UseSqlServer(ConfigurationHelper.Configuration.GetConnectionString("BoschContext")),
+                ServiceLifetime.Transient);
         }).
         Build();
 
         UnhandledException += App_UnhandledException;
-    }
-
-    private static void ConfigSetup(IConfigurationBuilder builder)
-    {
-        builder.SetBasePath(Directory.GetCurrentDirectory())
-
-            .AddJsonFile("Y:\\Studium\\Data Science\\Sem6\\AWP\\Repo\\App\\appsettings.json", optional: false, reloadOnChange: true)
-
-            .AddEnvironmentVariables();
     }
 
     private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)


### PR DESCRIPTION
1 )DB Connectionstring in appsettings.json aufgenommen.

2) appsetings.json nach App.Core verschoben und Helpers\ConfigurationHelper.cs implementiert => Abhängigkeiten in App und App.Core vorhanden =>IConfigurationBuilder und IConfigurationRoot können direkt aus der neuen Klasse aufgerufen werden, um wiederholten Code zu vermeiden.

3) appsettings.json in git.ignore hinzugefügt, um nicht wieder vor dem selben Problem zu stehen.

4) Tests durchgeführt, keine Auffälligkeiten.

5) Jeder User muss einmalig in der appsettings.json den Connectionstring anpassen.