### PR TITLE
Cherrypick bos 33

### DIFF
--- a/App/ViewModels/PcbSingleViewModel.cs
+++ b/App/ViewModels/PcbSingleViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using static ZXing.QrCode.Internal.Version;
 
 namespace App.ViewModels;
 
@@ -76,7 +77,7 @@ public partial class PcbSingleViewModel : ObservableValidator, INavigationAware
     private readonly IInfoBarService _infoBarService;
     private readonly INavigationService _navigationService;
 
-    public PcbSingleViewModel(ICrudService<Pcb> crudService, IInfoBarService infoBarService, IDialogService dialogService, INavigationService navigationService)
+    public PcbSingleViewModel(IPcbDataService<Pcb> crudService, IInfoBarService infoBarService, IDialogService dialogService, INavigationService navigationService)
     {
         _crudService = crudService;
         _dialogService = dialogService;
@@ -103,10 +104,12 @@ public partial class PcbSingleViewModel : ObservableValidator, INavigationAware
         var result = await _dialogService.ConfirmDeleteDialogAsync("Leiterplatte Löschen", "Sind Sie sicher, dass Sie diesen Eintrag löschen möchten?");
         if (result != null && result == true)
         {
+            //TODO: entkommentieren wenn einzel Ansicht passt
             //Pcb pcbToRemove = _selectedItem;
             //_pcb.Remove(pcbToRemove);
-            //await _crudService.Delete(pcbToRemove);
+            //await _crudService.Delete(_pcb);
             _infoBarService.showMessage("Erfolgreich Leiterplatte gelöscht", "Erfolg");
+            _navigationService.NavigateTo("App.ViewModels.PcbPaginationViewModel");
 
         }
     }

--- a/App/Views/PcbSinglePage.xaml
+++ b/App/Views/PcbSinglePage.xaml
@@ -50,7 +50,7 @@
                     Orientation="Horizontal">
                     <CommandBar DefaultLabelPosition="Right">
                         <AppBarButton Icon="Edit" Label="Bearbeiten" />
-                        <AppBarButton Icon="Delete" Label="Löschen" />
+                        <AppBarButton Icon="Delete" Label="Löschen" Click="DeleteClick" />
                     </CommandBar>
                 </StackPanel>
             </Grid>

--- a/App/Views/PcbSinglePage.xaml.cs
+++ b/App/Views/PcbSinglePage.xaml.cs
@@ -51,6 +51,11 @@ public sealed partial class PcbSinglePage : Page
         await printSerivce.Print(PcbSinglePageContent); //Test
     }
 
+    private void DeleteClick(object sender, RoutedEventArgs e)
+    {
+        ViewModel.DeleteCommand.Execute(null);
+    }
+
     private void GenerateBarcode()
     {
         IDataMatrixService dms = new DataMatrixService();


### PR DESCRIPTION
Löschen von Leiterplatten ist nun über den Button auf der Hauptansicht möglich, auf der Einzelansicht gibt es zur Zeit noch kein Binding auf wirkliche Leiterplatten. Deshalb sind dort die relevanten Zeilen noch aus kommentiert.

Zu beachten ist, dass der PcbDataService für die Pagination noch nicht darauf geachtete hat, ob Leiterplatten bereits gelöscht sind oder nicht.

Diese Anpassung ist auch auf diesem Branch, deshalb gilt zu beachten, das die Testdaten ggf. angepasst werden müssen, um immer noch in der Übersicht einsehbar zu sein.