### PR TITLE
Bos fix transfer 310523

### DIFF
--- a/App.Core/Models/Comment.cs
+++ b/App.Core/Models/Comment.cs
@@ -13,6 +13,7 @@ namespace App.Core.Models
         {
             get; set;
         }
+
         [Required]
         public User NotedBy
         {

--- a/App.Core/Services/Interfaces/ITransferDataService.cs
+++ b/App.Core/Services/Interfaces/ITransferDataService.cs
@@ -5,6 +5,7 @@ namespace App.Core.Services.Interfaces
     public interface ITransferDataService<T> : ICrudService<T> where T : Transfer
     {
         public Task<Response<List<T>>> GetTransfersByPcb(int pcbId);
-        public Task<ResponseCode> CreateTransfer(Transfer transfer, int diagnoseId);
+        public Task<Response<T>> CreateTransfer(T transfer, int diagnoseId);
+
     }
 }

--- a/App.Core/Services/TransferDataService.cs
+++ b/App.Core/Services/TransferDataService.cs
@@ -3,6 +3,7 @@ using App.Core.Models;
 using App.Core.Services.Base;
 using App.Core.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 
 namespace App.Core.Services
 {
@@ -30,25 +31,26 @@ namespace App.Core.Services
         }
 
 
-        public async Task<ResponseCode> CreateTransfer(Transfer transfer, int diagnoseId)
+        public async Task<Response<T>> CreateTransfer(T transfer, int diagnoseId)
         {
             using (var transaction = await _boschContext.Database.BeginTransactionAsync())
             {
                 try
                 {
-                    await _boschContext.Set<Transfer>().AddAsync(transfer);
+                    EntityEntry<T> entityEntry = await _boschContext.Set<T>().AddAsync(transfer);
                     var pcb = await _boschContext.Set<Pcb>().FirstOrDefaultAsync(x => x.Id == transfer.PcbId);
                     pcb.DiagnoseId = diagnoseId;
 
                     await _boschContext.SaveChangesAsync();
                     await transaction.CommitAsync();
+                    return new Response<T>(ResponseCode.Success, (T)entityEntry.Entity);
 
                 }
                 catch (Exception)
                 {
-                    return ResponseCode.Error;
+                    return new Response<T>(ResponseCode.Error, error: $"Fehler beim Erstellen von {typeof(T)}");
                 }
-                return ResponseCode.Success;
+
             }
         }
     }

--- a/App/App.csproj
+++ b/App/App.csproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Controls\ErrorCardUserControl.xaml" />
+    <None Remove="Controls\TransferDialog.xaml" />
     <None Remove="Views\CreateDiagnosePage.xaml" />
     <None Remove="Views\DiagnosePage.xaml" />
     <None Remove="Views\PcbViewPage.xaml" />
@@ -77,6 +78,12 @@
     <Compile Update="Views\UpdateDiagnosePage.xaml.cs">
       <Generator></Generator>
     </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Page Update="Controls\TransferDialog.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
 
   <ItemGroup>

--- a/App/App.xaml.cs
+++ b/App/App.xaml.cs
@@ -129,6 +129,7 @@ public partial class App : Application
             //services.AddTransient<CreateStorageLocation>();
             services.AddTransient<StorageLocation>();
             services.AddTransient<StorageLocationViewModel>();
+            services.AddTransient<TransferDialogViewModel>();
 
 
             // Configuration

--- a/App/Contracts/Services/IDialogService.cs
+++ b/App/Contracts/Services/IDialogService.cs
@@ -3,9 +3,8 @@ using Microsoft.UI.Xaml;
 namespace App.Contracts.Services;
 public interface IDialogService
 {
-    //TODO Extend the Interface -> InputDialog 
     Task<bool?> ConfirmDeleteDialogAsync(string title, string content, string confirmButtonText = "Löschen", string cancelButtonText = "Abbrechen");
     void UnAuthorizedDialogAsync(string title, string content, XamlRoot xamlRoot);
 
-    Task<Tuple<Transfer, int>?> ShowCreateTransferDialog(string title, User user, List<StorageLocation> storageLocations, List<Diagnose> diagnoses, string confirmButtonText = "Weitergeben", string cancelButtonText = "Abbrechen");
+    Task<Tuple<Transfer, int?>?> ShowCreateTransferDialog(string title, string confirmButtonText = "Weitergeben", string cancelButtonText = "Abbrechen");
 }

--- a/App/Controls/TransferDialog.xaml
+++ b/App/Controls/TransferDialog.xaml
@@ -1,0 +1,69 @@
+﻿<!--  Copyright (c) Microsoft Corporation and Contributors.  -->
+<!--  Licensed under the MIT License.  -->
+
+<UserControl
+    x:Class="App.Controls.TransferDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:App.Converters"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+
+    <UserControl.Resources>
+        <local:TimeConverter x:Key="TimeConverter" />
+    </UserControl.Resources>
+
+
+
+    <Grid RowSpacing="20">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition />
+            <ColumnDefinition />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition />
+            <RowDefinition />
+            <RowDefinition />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+        <CalendarDatePicker
+            Grid.Row="0"
+            Grid.Column="0"
+            Date="{x:Bind ViewModel.TransferDate, Mode=TwoWay, Converter={StaticResource TimeConverter}}"
+            Header="Eingang" />
+        <TextBox
+            Grid.Row="0"
+            Grid.Column="1"
+            Header="Weitergabe durch"
+            IsEnabled="False"
+            Text="{x:Bind ViewModel.NotedBy.Name, Mode=TwoWay}" />
+        <ComboBox
+            Grid.Row="1"
+            Grid.Column="0"
+            DisplayMemberPath="StorageName"
+            Header="Ort"
+            ItemsSource="{x:Bind ViewModel.StorageLocations, Mode=OneWay}"
+            PlaceholderText="auswählen"
+            SelectedItem="{x:Bind ViewModel.SelectedStorageLocation, Mode=TwoWay}" />
+        <ComboBox
+            Grid.Row="1"
+            Grid.Column="1"
+            DisplayMemberPath="Name"
+            Header="Fehlerkategorie"
+            ItemsSource="{x:Bind ViewModel.Diagnoses, Mode=OneWay}"
+            PlaceholderText="auswählen"
+            SelectedItem="{x:Bind ViewModel.SelectedDiagnose, Mode=TwoWay}"
+            Visibility="{x:Bind ViewModel.IsVisible, Mode=OneWay}" />
+        <TextBox
+            Grid.Row="2"
+            Grid.ColumnSpan="2"
+            Header="Beurteilung | Anmerkung"
+            PlaceholderText="Text eintragen"
+            Text="{x:Bind ViewModel.Comment, Mode=TwoWay}" />
+
+
+
+    </Grid>
+</UserControl>

--- a/App/Controls/TransferDialog.xaml.cs
+++ b/App/Controls/TransferDialog.xaml.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+
+using App.ViewModels;
+using Microsoft.UI.Xaml.Controls;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace App.Controls
+{
+    public sealed partial class TransferDialog : UserControl
+    {
+        public TransferDialogViewModel ViewModel
+        {
+            get;
+        }
+
+        public TransferDialog()
+        {
+            ViewModel = App.GetService<TransferDialogViewModel>();
+            InitializeComponent();
+        }
+    }
+}

--- a/App/Services/DialogService.cs
+++ b/App/Services/DialogService.cs
@@ -1,8 +1,9 @@
 ﻿using App.Contracts.Services;
+using App.Controls;
 using App.Core.Models;
+using App.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-
 
 namespace App.Services;
 
@@ -41,86 +42,16 @@ public sealed class DialogService : IDialogService
         }
         return null;
     }
-    public async Task<Tuple<Transfer, int>?> ShowCreateTransferDialog(string title, User user, List<StorageLocation> storageLocations, List<Diagnose> diagnoses, string confirmButtonText, string cancelButtonText)
+    public async Task<Tuple<Transfer, int?>?> ShowCreateTransferDialog(string title, string confirmButtonText, string cancelButtonText)
     {
+
+
         if (rootElement != null)
-
         {
-            Grid DynamicGrid = new Grid { RowSpacing = 20 };
-            ColumnDefinition gridCol1 = new ColumnDefinition();
-            ColumnDefinition gridCol2 = new ColumnDefinition();
-
-            DynamicGrid.ColumnDefinitions.Add(gridCol1);
-            DynamicGrid.ColumnDefinitions.Add(gridCol2);
-
-            RowDefinition gridRow1 = new RowDefinition();
-            RowDefinition gridRow2 = new RowDefinition();
-            RowDefinition gridRow3 = new RowDefinition();
-
-            DynamicGrid.RowDefinitions.Add(gridRow1);
-            DynamicGrid.RowDefinitions.Add(gridRow2);
-            DynamicGrid.RowDefinitions.Add(gridRow3);
-
-            CalendarDatePicker transferDate = new CalendarDatePicker
-            {
-                Header = "Eingang",
-                Date = DateTime.Today
-            };
-            Grid.SetRow(transferDate, 0);
-            Grid.SetColumn(transferDate, 0);
-            DynamicGrid.Children.Add(transferDate);
-
-            TextBox username = new TextBox
-            {
-                Header = "aufgenommen von:",
-                Text = user.Name,
-                IsReadOnly = true,
-            };
-            Grid.SetRow(username, 0);
-            Grid.SetColumn(username, 1);
-            DynamicGrid.Children.Add(username);
-
-            ComboBox storageLocation = new ComboBox
-            {
-                Header = "Ort",
-                PlaceholderText = "auswählen",
-                ItemsSource = storageLocations,
-                DisplayMemberPath = "StorageName"
-
-            };
-            Grid.SetRow(storageLocation, 1);
-            Grid.SetColumn(storageLocation, 0);
-            DynamicGrid.Children.Add(storageLocation);
-
-
-            ComboBox diagnose = new ComboBox
-            {
-                Header = "Fehlerkategorie",
-                PlaceholderText = "auswählen",
-                ItemsSource = diagnoses,
-                DisplayMemberPath = "Name"
-
-
-            };
-            Grid.SetRow(diagnose, 1);
-            Grid.SetColumn(diagnose, 1);
-            DynamicGrid.Children.Add(diagnose);
-
-            TextBox comment = new TextBox
-            {
-                Header = "Beurteilung | Anmerkung",
-                PlaceholderText = "Text eintragen"
-            };
-
-            Grid.SetRow(comment, 2);
-            Grid.SetColumnSpan(comment, 2);
-            DynamicGrid.Children.Add(comment);
-
-
             var dialog = new ContentDialog
             {
                 Title = title,
-                Content = DynamicGrid,
+                Content = new TransferDialog(),
                 PrimaryButtonText = confirmButtonText,
                 DefaultButton = ContentDialogButton.Primary,
                 RequestedTheme = rootElement.RequestedTheme,
@@ -129,6 +60,7 @@ public sealed class DialogService : IDialogService
 
             };
             var result = await dialog.ShowAsync();
+            var view = (TransferDialog)dialog.Content;
 
             if (result == ContentDialogResult.None)
             {
@@ -136,16 +68,18 @@ public sealed class DialogService : IDialogService
             }
             if (result == ContentDialogResult.Primary)
             {
+                TransferDialogViewModel tdVM = (TransferDialogViewModel)view.ViewModel;
+
+                int? diagnoseId = ((Diagnose)tdVM.SelectedDiagnose) != null ? ((Diagnose)tdVM.SelectedDiagnose).Id : null;
 
                 return Tuple.Create(new Transfer
                 {
-                    NotedById = user.Id,
-                    CreatedDate = transferDate.Date.Value.DateTime,
-                    StorageLocationId = ((StorageLocation)storageLocation.SelectedItem).Id,
-                    Comment = comment.Text
-                }, ((Diagnose)diagnose.SelectedItem).Id);
+                    NotedById = tdVM.NotedBy.Id,
+                    CreatedDate = tdVM.TransferDate,
+                    StorageLocationId = ((StorageLocation)tdVM.SelectedStorageLocation).Id,
+                    Comment = tdVM.Comment
+                }, diagnoseId);
             }
-
         }
         return null;
     }

--- a/App/ViewModels/PcbPaginationViewModel.cs
+++ b/App/ViewModels/PcbPaginationViewModel.cs
@@ -1,7 +1,6 @@
 ﻿using App.Contracts.Services;
 using App.Core.Models;
 using App.Core.Models.Enums;
-using App.Core.Services;
 using App.Core.Services.Interfaces;
 using App.Models;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -19,13 +18,10 @@ namespace App.ViewModels
             IInfoBarService infoBarService,
             IDialogService dialogService,
             INavigationService navigationService,
-                IAuthenticationService authenticationService,
-            ITransferDataService<Transfer> transferDataService,
-            ICrudService<Diagnose> diagnoseCrudService
+            ITransferDataService<Transfer> transferDataService
         )
         {
             _pcbDataService = pcbDataService;
-            _authenticationService = authenticationService;
             FirstAsyncCommand = new AsyncRelayCommand(
                 async () => await GetPcbs(1, _pageSize, _isSortingAscending),
                 () => _pageNumber != 1
@@ -60,19 +56,16 @@ namespace App.ViewModels
             _dialogService = dialogService;
             _infoBarService = infoBarService;
             _navigationService = navigationService;
-            _storageLocationCrudService = storageLocationDataService;
-            _diagnoseCrudService = diagnoseCrudService;
             _transferDataService = transferDataService;
+            _storageLocationCrudService = storageLocationDataService;
             Refresh();
         }
 
         private readonly IPcbDataService<Pcb> _pcbDataService;
         private readonly ICrudService<StorageLocation> _storageLocationCrudService;
-        private readonly ICrudService<Diagnose> _diagnoseCrudService;
         private readonly IInfoBarService _infoBarService;
         private readonly IDialogService _dialogService;
         private readonly INavigationService _navigationService;
-        private readonly IAuthenticationService _authenticationService;
         private readonly ITransferDataService<Transfer> _transferDataService;
 
         public IAsyncRelayCommand FirstAsyncCommand { get; }
@@ -283,40 +276,34 @@ namespace App.ViewModels
         [RelayCommand]
         public async void ShowTransfer()
         {
-            User currentUser = _authenticationService.currentUser();
-            var storageLocationsResponse = await _storageLocationCrudService.GetAll();
-            var storageLocations = new List<StorageLocation>();
-            if (storageLocationsResponse.Code == ResponseCode.Success)
-            {
-                storageLocations = storageLocationsResponse.Data;
-            }
-
-            var diagnoseResponse = await _diagnoseCrudService.GetAll();
-            var diagnoses = new List<Diagnose>();
-            if (diagnoseResponse.Code == ResponseCode.Success)
-            {
-                diagnoses = diagnoseResponse.Data;
-            }
-            var result = await _dialogService.ShowCreateTransferDialog("Weitergabe", currentUser, storageLocations, diagnoses);
+            var result = await _dialogService.ShowCreateTransferDialog("Weitergabe");
             if (result != null)
             {
                 Transfer transfer = result.Item1;
-                int diagnoseId = result.Item2;
+                int? diagnoseId = result.Item2;
 
                 transfer.PcbId = _selectedItem.Id;
 
-                var response = await _transferDataService.CreateTransfer(transfer, diagnoseId);
-                if (response == ResponseCode.Success)
+                Response<Transfer> response;
+
+                if (diagnoseId.HasValue)
                 {
+                    response = await _transferDataService.CreateTransfer(transfer, (int)diagnoseId);
+                }
+                else
+                {
+                    response = await _transferDataService.Create(transfer);
+                }
+
+                if (response.Code == ResponseCode.Success)
+                {
+
                     _infoBarService.showMessage("Weitergabe erfolgreich", "Erfolg");
                 }
                 else
                 {
                     _infoBarService.showError("Fehler bei der Weitergabe", "Error");
-
                 }
-
-
             }
         }
 

--- a/App/ViewModels/PcbSingleViewModel.cs
+++ b/App/ViewModels/PcbSingleViewModel.cs
@@ -260,7 +260,7 @@ public partial class PcbSingleViewModel : ObservableValidator, INavigationAware
 
     private void Refresh(object parameter)
     {
-        _navigationService.NavigateTo("App.ViewModels.SinglePcbViewModel", _selectedItem);
+        _navigationService.NavigateTo("App.ViewModels.PcbSingleViewModel", _selectedItem);
     }
 
     [RelayCommand]

--- a/App/ViewModels/TransferDialogViewModel.cs
+++ b/App/ViewModels/TransferDialogViewModel.cs
@@ -1,0 +1,79 @@
+﻿using App.Core.Models;
+using App.Core.Services.Interfaces;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.UI.Xaml;
+using System.Collections.ObjectModel;
+
+namespace App.ViewModels;
+
+public partial class TransferDialogViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private Visibility _isVisible = Visibility.Collapsed;
+
+    [ObservableProperty]
+    private User _notedBy;
+
+    [ObservableProperty]
+    private DateTime _transferDate = DateTime.Now;
+
+    private StorageLocation _selectedStorageLocation;
+    public StorageLocation SelectedStorageLocation
+    {
+        get => _selectedStorageLocation;
+        set
+        {
+            if (value.IsFinalDestination == true)
+            {
+                IsVisible = Visibility.Visible;
+            }
+            else
+            {
+                IsVisible = Visibility.Collapsed;
+            }
+            SetProperty(ref _selectedStorageLocation, value);
+        }
+    }
+
+    [ObservableProperty]
+    private Diagnose _selectedDiagnose;
+
+    [ObservableProperty]
+    private string _comment;
+
+    [ObservableProperty]
+    private ObservableCollection<StorageLocation> _storageLocations = new();
+
+    [ObservableProperty]
+    private ObservableCollection<Diagnose> _diagnoses = new();
+
+    private readonly IAuthenticationService _authenticationService;
+    private readonly ICrudService<StorageLocation> _storageLocationCrudService;
+    private readonly ICrudService<Diagnose> _diagnoseCrudService;
+    public TransferDialogViewModel(IAuthenticationService authenticationService, ICrudService<StorageLocation> storageLocationCrudService, ICrudService<Diagnose> diagnoseCrudService)
+    {
+        _authenticationService = authenticationService;
+        _diagnoseCrudService = diagnoseCrudService;
+        _storageLocationCrudService = storageLocationCrudService;
+        _notedBy = _authenticationService.currentUser();
+        LoadData();
+    }
+
+    private async void LoadData()
+    {
+
+        //TODO: Error handling
+        var resStorageLocations = await _storageLocationCrudService.GetAll();
+        if (resStorageLocations.Code == ResponseCode.Success)
+        {
+            resStorageLocations.Data.ForEach(x => _storageLocations.Add(x));
+        }
+
+        var resDiagnoses = await _diagnoseCrudService.GetAll();
+        if (resDiagnoses.Code == ResponseCode.Success)
+        {
+            resDiagnoses.Data.ForEach(x => _diagnoses.Add(x));
+        }
+    }
+}
+


### PR DESCRIPTION
Transfer Dialog wurde umgeschrieben, damit man die Fehlerkategorie ein und ausblenden kann abhängig vom Lagerort (Endverbleib ja/nein). Ist jetzt eine deutlich schöner Variante mit eigener UserControl und ViewModel. Änderungen in PcbSingleViewModel und PcbPaginationViewModel, zur Kontrolle wurde händisch durchgeklickt. In beiden Ansichten können Weitergaben erstellt werden.