### PR TITLE
BOS-327

### DIFF
--- a/App.Core/Services/PcbDataService.cs
+++ b/App.Core/Services/PcbDataService.cs
@@ -183,7 +183,7 @@ public class PcbDataService<T> : CrudServiceBase<T>, IPcbDataService<T> where T 
                     .AsNoTracking()
                     .ToListAsync();
             }
-            
+
             return new Response<List<T>>(ResponseCode.Success, data: data);
         }
         catch (DbUpdateException)
@@ -344,7 +344,6 @@ public class PcbDataService<T> : CrudServiceBase<T>, IPcbDataService<T> where T 
                 .Include(T => T.Diagnose)
                 .Include(T => T.PcbType)
                 .Include(T => T.ErrorTypes)
-                .AsNoTracking()
                 .FirstAsync(x => x.Id == id);
             return new Response<T>(ResponseCode.Success, entity);
         }


### PR DESCRIPTION
Löschen von AsNoTracking, da dies zu Tracking Problemen geführt hat und InvalidOperationException hervorgerufen hat beim Speichern der Leiterplatte, sobald man die 2. Weitergabe gemacht hat, da dann versucht wurde das gleiche User Objekt mehr mals zu tracken.