### PR TITLE
fixed transfer of pcb inside details view on newly created pcb

### DIFF
--- a/App.Core/Services/PcbDataService.cs
+++ b/App.Core/Services/PcbDataService.cs
@@ -344,6 +344,7 @@ public class PcbDataService<T> : CrudServiceBase<T>, IPcbDataService<T> where T 
                 .Include(T => T.Diagnose)
                 .Include(T => T.PcbType)
                 .Include(T => T.ErrorTypes)
+                .AsNoTrackingWithIdentityResolution()
                 .FirstAsync(x => x.Id == id);
             return new Response<T>(ResponseCode.Success, entity);
         }

--- a/App.Core/Services/TransferDataService.cs
+++ b/App.Core/Services/TransferDataService.cs
@@ -46,10 +46,6 @@ namespace App.Core.Services
                     }
 
                     pcb.Finalized = storageLocation.IsFinalDestination;
-
-                    _boschContext.Entry(pcb).Property(x => x.DiagnoseId).IsModified = true;
-                    _boschContext.Entry(pcb).Property(x => x.Finalized).IsModified = true;
-
                     await _boschContext.SaveChangesAsync();
                     await transaction.CommitAsync();
                     return new Response<T>(ResponseCode.Success, (T)entityEntry.Entity);

--- a/App/ViewModels/PcbPaginationViewModel.cs
+++ b/App/ViewModels/PcbPaginationViewModel.cs
@@ -368,6 +368,12 @@ namespace App.ViewModels
             _navigationService.NavigateTo("App.ViewModels.UpdatePcbViewModel", pcb);
         }
 
+        [RelayCommand]
+        public void NavigateToCreate()
+        {
+            _navigationService.NavigateTo("App.ViewModels.CreatePcbViewModel");
+        }
+
         private void Refresh()
         {
             _pageNumber = 0;
@@ -386,7 +392,7 @@ namespace App.ViewModels
             );
 
         }
-        // Unregister Messneger when Page is navigated away from
+        // Unregister Messenger when Page is navigated away from
         protected override void OnDeactivated()
         {
             Messenger.UnregisterAll(this);

--- a/App/ViewModels/PcbSingleViewModel.cs
+++ b/App/ViewModels/PcbSingleViewModel.cs
@@ -100,9 +100,6 @@ public partial class PcbSingleViewModel : ObservableValidator, INavigationAware
     private int _inCirculationDays;
 
     [ObservableProperty]
-    private string _colorDays;
-
-    [ObservableProperty]
     private int _atLocationDays;
 
     [ObservableProperty]
@@ -115,33 +112,28 @@ public partial class PcbSingleViewModel : ObservableValidator, INavigationAware
 
 
     private readonly IAuthenticationService _authenticationService;
-    private readonly ICrudService<StorageLocation> _storageLocationCrudService;
-    private readonly ICrudService<Diagnose> _diagnoseCrudService;
     private readonly ICrudService<Pcb> _pcbCrudService;
     private readonly IPcbDataService<Pcb> _pcbDataService;
-    private readonly ICrudService<StorageLocation> _storageService;
     private readonly ICrudService<Comment> _commentService;
-    private readonly ICrudService<Device> _deviceService;
     private readonly IDialogService _dialogService;
     private readonly IInfoBarService _infoBarService;
     private readonly INavigationService _navigationService;
     private readonly ITransferDataService<Transfer> _transfersService;
 
-    private Pcb _oldPcb;
-
-    public IAsyncRelayCommand FirstAsyncCommand { get; }
-
-
-    public PcbSingleViewModel(IPcbDataService<Pcb> pcbDataService, ICrudService<Pcb> pcbCrudService, ICrudService<StorageLocation> storageService, ICrudService<StorageLocation> storageLocationCrudService, ICrudService<Diagnose> diagnoseCrudService, IInfoBarService infoBarService, ICrudService<Comment> commentService, ICrudService<Device> deviceService, IDialogService dialogService, INavigationService navigationService, IAuthenticationService authenticationService, ITransferDataService<Transfer> transfersService)
+    public PcbSingleViewModel(
+        IPcbDataService<Pcb> pcbDataService,
+        ICrudService<Pcb> pcbCrudService,
+        IInfoBarService infoBarService,
+        ICrudService<Comment> commentService,
+        IDialogService dialogService,
+        INavigationService navigationService,
+        IAuthenticationService authenticationService,
+        ITransferDataService<Transfer> transfersService)
     {
         _pcbDataService = pcbDataService;
         _authenticationService = authenticationService;
-        _storageLocationCrudService = storageLocationCrudService;
-        _diagnoseCrudService = diagnoseCrudService;
         _pcbCrudService = pcbCrudService;
-        _storageService = storageService;
         _commentService = commentService;
-        _deviceService = deviceService;
         _dialogService = dialogService;
         _infoBarService = infoBarService;
         _navigationService = navigationService;
@@ -161,7 +153,7 @@ public partial class PcbSingleViewModel : ObservableValidator, INavigationAware
             addedTransfer.Id = SortedData.Count() + 1;
             SortedData.Insert(0, addedTransfer);
             _infoBarService.showMessage("Weitergabe erfolgreich", "Erfolg");
-
+            await Load();
         }
         else if ((response != null && response.Code == ResponseCode.Error) || response == null)
         {
@@ -169,10 +161,6 @@ public partial class PcbSingleViewModel : ObservableValidator, INavigationAware
         }
     }
 
-    private void Refresh(object parameter)
-    {
-        _navigationService.NavigateTo("App.ViewModels.PcbSingleViewModel", _selectedItem);
-    }
 
     [RelayCommand]
     public void Edit()
@@ -268,21 +256,8 @@ public partial class PcbSingleViewModel : ObservableValidator, INavigationAware
         RestrictionButtonVisibility = Visibility.Collapsed;
     }
 
-
-    // Unregister Messneger when Page is navigated away from
-
-    public async void OnNavigatedTo(object parameter)
+    public async Task Load()
     {
-        _pcb = (Pcb)parameter;
-
-        _selectedItem = _pcb;
-
-        // Register Messenger used with ShowTransfer
-        WeakReferenceMessenger.Default.Register<PcbSingleViewModel, CurrentPcbRequestMessage>(this, (r, m) =>
-        {
-            m.Reply(r.SelectedItem);
-        });
-
         var result = await _pcbDataService.GetByIdEager(SelectedItem.Id);
 
         _pcb = result.Data;
@@ -327,38 +302,16 @@ public partial class PcbSingleViewModel : ObservableValidator, INavigationAware
 
 
         Finalized = _pcb.Finalized;
-        if (!Finalized)
-        {
-            Status = "offen";
-        }
-        else
-        {
-            Status = "abgeschlossen";
-        }
-
+        Status = Finalized ? "abgeschlossen" : "offen";
         PcbType = _pcb.PcbType;
         PanelComment = _pcb.Comment;
         DiagnosePcb = _pcb.Diagnose;
-        NotedBy = (_pcb.Transfers.Last()).NotedBy.Name;
-        AtLocationDays = 5;
+        NotedBy = _pcb.Transfers.Last().NotedBy.Name;
 
         InCirculationDays = (int)Math.Round((DateTime.Now - _pcb.CreatedDate).TotalDays);
-        if (InCirculationDays > 5)
-        {
-            ColorDays = "yellow";
-        }
-        else if (InCirculationDays > 10)
-        {
-            ColorDays = "red";
-        }
-        else
-        {
-            ColorDays = "green";
-        }
 
         var transfers = await _transfersService.GetTransfersByPcb(_pcb.Id);
 
-        //_transfers = new ObservableCollection<Transfer>();
         if (transfers.Code == ResponseCode.Success)
         {
             for (int i = 0; i < (transfers.Data).Count; i++)
@@ -389,6 +342,10 @@ public partial class PcbSingleViewModel : ObservableValidator, INavigationAware
                             ColorTransferDays = new SolidColorBrush(Colors.LimeGreen);
                         }
                     }
+                    else
+                    {
+                        ColorTransferDays = new SolidColorBrush(Colors.Transparent);
+                    }
                 }
             }
             SortedData = new ObservableCollection<Transfer>(transfers.Data.ToList().OrderByDescending(x => x.CreatedDate));
@@ -399,14 +356,25 @@ public partial class PcbSingleViewModel : ObservableValidator, INavigationAware
         }
     }
 
+
+    public async void OnNavigatedTo(object parameter)
+    {
+        _pcb = (Pcb)parameter;
+
+        SelectedItem = _pcb;
+
+        // Register Messenger used with ShowTransfer
+        WeakReferenceMessenger.Default.Register<PcbSingleViewModel, CurrentPcbRequestMessage>(this, (r, m) =>
+        {
+            m.Reply(r.SelectedItem);
+        });
+
+        await Load();
+    }
+
     public void OnNavigatedFrom()
     {
         WeakReferenceMessenger.Default.UnregisterAll(this);
-    }
-
-    private void NavigateToPcbs()
-    {
-        _navigationService.NavigateTo("App.ViewModels.PcbPaginationViewModel");
     }
 
 }

--- a/App/ViewModels/PcbSingleViewModel.cs
+++ b/App/ViewModels/PcbSingleViewModel.cs
@@ -157,19 +157,10 @@ public partial class PcbSingleViewModel : ObservableValidator, INavigationAware
         var response = await _dialogService.ShowCreateTransferDialog();
         if (response != null && response.Code == ResponseCode.Success)
         {
-            Transfer addedTransfer = response.Data;
-            var responseTransfer = await _transfersService.GetById(addedTransfer.Id);
-            if (responseTransfer != null && responseTransfer.Code == ResponseCode.Success)
-            {
-                addedTransfer = responseTransfer.Data;
-                addedTransfer.Id = SortedData.Count() + 1;
-                SortedData.Insert(0, addedTransfer);
-                _infoBarService.showMessage("Weitergabe erfolgreich", "Erfolg");
-            }
-            else
-            {
-                _infoBarService.showError("Fehler bei der Weitergabe", "Error");
-            }
+            var addedTransfer = response.Data;
+            addedTransfer.Id = SortedData.Count() + 1;
+            SortedData.Insert(0, addedTransfer);
+            _infoBarService.showMessage("Weitergabe erfolgreich", "Erfolg");
 
         }
         else if ((response != null && response.Code == ResponseCode.Error) || response == null)

--- a/App/ViewModels/TransferDialogViewModel.cs
+++ b/App/ViewModels/TransferDialogViewModel.cs
@@ -124,10 +124,6 @@ public partial class TransferDialogViewModel : ObservableValidator
 
 
     }
-    private bool CanExecute()
-    {
-        return false;
-    }
 
 }
 

--- a/App/Views/PcbViewPage.xaml
+++ b/App/Views/PcbViewPage.xaml
@@ -99,17 +99,17 @@
                         Grid.Column="1"
                         HorizontalAlignment="Right"
                         Text="{Binding LastStorageLocationName}" />
-                    <TextBlock 
+                    <TextBlock
                         Grid.Row="4"
                         Grid.Column="1"
                         HorizontalAlignment=" Right"
-                        Text="{Binding AtLocationDays}"/>
+                        Text="{Binding AtLocationDays}" />
                     <Ellipse
+                        Width="22"
+                        Height="22"
                         Fill="{Binding Status}"
                         Stroke="Black"
-                        StrokeThickness="0.2"
-                        Height="22" 
-                        Width="22"/>
+                        StrokeThickness="0.2" />
                     <TextBlock
                         Grid.Row="5"
                         Grid.Column="1"
@@ -278,21 +278,21 @@
                     Tag="LastStorageLocation" />
                 <ctWinUI:DataGridTextColumn
                     Binding="{Binding AtLocationDays}"
+                    CanUserSort="False"
                     Header="Verweildauer"
-                    Tag="AtLocationDays"
-                    CanUserSort="False"/>
-                <ctWinUI:DataGridTemplateColumn 
+                    Tag="AtLocationDays" />
+                <ctWinUI:DataGridTemplateColumn
+                    CanUserSort="False"
                     Header="Status"
-                    Tag="Status"
-                    CanUserSort="False">
+                    Tag="Status">
                     <ctWinUI:DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
                             <Ellipse
+                                Width="22"
+                                Height="22"
                                 Fill="{Binding Status}"
                                 Stroke="Black"
-                                StrokeThickness="0.2"
-                                Height="22" 
-                                Width="22"/>
+                                StrokeThickness="0.2" />
                         </DataTemplate>
                     </ctWinUI:DataGridTemplateColumn.CellTemplate>
                 </ctWinUI:DataGridTemplateColumn>

--- a/App/Views/PcbViewPage.xaml.cs
+++ b/App/Views/PcbViewPage.xaml.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation and Contributors.
 // Licensed under the MIT License.
 
-using ABI.Microsoft.UI.Xaml.Input;
 using App.Core.Models;
 using App.Core.Models.Enums;
 using App.ViewModels;
@@ -9,19 +8,10 @@ using CommunityToolkit.WinUI.UI.Controls;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
-using System.Diagnostics;
 using ctWinUI = CommunityToolkit.WinUI.UI.Controls;
-using System.Windows.Input;
-
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace App.Views
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class PcbViewPage : Page
     {
         private enum DataGridDisplayMode
@@ -183,7 +173,7 @@ namespace App.Views
 
         private void CreatePcbButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
-            Frame.Navigate(typeof(CreatePcbPage));
+            ViewModel.NavigateToCreateCommand.Execute(null);
         }
 
         private void DataGridItemsSourceChangedCallback(DependencyObject sender, DependencyProperty dp)
@@ -224,12 +214,5 @@ namespace App.Views
         {
             ViewModel.ShowTransferCommand.Execute(null);
         }
-
-        /*private void UIElement_OnLostFocus(object sender, RoutedEventArgs e)
-        {
-            Debug.WriteLine("ok");
-        }*/
-
-
     }
 }


### PR DESCRIPTION
Bug Fix: Leiterplatten können direkt nach dem Erstellen über die Detailansicht weitergegeben werden. Refactoring des SinglePcbViewModel, damit die Seite neu geladen werden kann.