### PR TITLE
Fix Plot-Anzeige in Sachnummer-Auswertung

### DIFF
--- a/App/ViewModels/PcbTypeEvaluationViewModel.cs
+++ b/App/ViewModels/PcbTypeEvaluationViewModel.cs
@@ -112,6 +112,7 @@ public partial class PcbTypeEvaluationViewModel : ObservableRecipient, INavigati
 
     public async Task GeneratePlot() 
     {
+        PcbTypeFinalizedModel = new PlotModel();
         PcbTypeFinalizedModel = await CreatePieChart();       
     }
 
@@ -147,7 +148,13 @@ public partial class PcbTypeEvaluationViewModel : ObservableRecipient, INavigati
 
         var storage = new List<StorageLocation>();
         var response = await _pcbTypeEvaluationService.GetAllByPcbType(SelectedPcbType.PcbPartNumber, Deadline);
-        if (response != null && response.Code == ResponseCode.Success)
+
+
+        if (response != null && response.Code == ResponseCode.Success && response.Data.Count == 0)
+        {
+            _infoBarService.showMessage("Keine Daten vorhanden", "Info");
+        }
+        else if (response != null && response.Code == ResponseCode.Success)
         {
             foreach (var item in response.Data)
             {

--- a/App/Views/DwellTimeEvalutionPage.xaml
+++ b/App/Views/DwellTimeEvalutionPage.xaml
@@ -25,7 +25,7 @@
         
         <StackPanel
             Grid.Row="0"
-            Height="52"
+            Height="Auto"
             Margin="50,0,0,0"
             HorizontalAlignment="Left"
             CornerRadius="4"

--- a/App/Views/PcbViewPage.xaml
+++ b/App/Views/PcbViewPage.xaml
@@ -51,7 +51,7 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <StackPanel
-            Height="52"
+            Height="Auto"
             Margin="0,0,0,16"
             HorizontalAlignment="Left"
             CornerRadius="4"


### PR DESCRIPTION
Plot wird bei keinen vorhandenen Daten nicht mehr angezeigt, Message erscheint dazu
& Anzeige der Buttons in Verweildauer-Auswertung gefixt